### PR TITLE
Don't tie us to such an overly-specific version of Elixir

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Ambi.MixProject do
     [
       app: :ambi,
       version: "0.1.0",
-      elixir: "1.13.1",
+      elixir: "~> 1.13.1",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Before this small fix if you weren't running Elixir 1.13.1 specifically on your dev machine, mix phx.server would error out wanting that specific version. This widens the version of Elixir up a bit to a sensible level.

**To Properly Review This Change**

1. Please pull down this PR, run `mix phx.server` to run the backend, and make sure that it builds successfully.