### PR TITLE
Add pre-commit code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ What Ambi's web-based UI looks like as of December, 2021
 
 <img width="1568" alt="Screen Shot 2021-07-06 at 10 00 20 PM" src="https://user-images.githubusercontent.com/3219120/124693833-b2764e80-dea5-11eb-8e3c-36dfb6ed2d48.png">
 
+## Set Up Git Hooks
+
+The Ambi repository makes use of several Git hooks to ensure that code quality standards are met and consistent. To automatically configure these hooks for your local workspace, you can run the following:
+```bash
+./scripts/create-git-hooks
+```
+
+This will create symlinks to the Git hooks, preserving any hooks that you may have already configured.
+
 ## Install Postgresql
 
 For macOS the [Postgreql.app](https://postgresapp.com/) is the easiest and best option for your local development machine. Version 12

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,7 +4,7 @@ database_url = System.get_env("DATABASE_URL")
 
 # Configure your database
 config :ambi, Ambi.Repo,
- # url: database_url,
+  # url: database_url,
   username: "postgres",
   password: "postgres",
   database: "ambi_dev",

--- a/lib/ambi.ex
+++ b/lib/ambi.ex
@@ -17,29 +17,34 @@ defmodule Ambi do
     %Ambi.Reading{}
     |> Ambi.Reading.changeset(attrs)
     |> Repo.insert()
-    #broadcast_change(:added)
-    #Logger.debug "Added new reading and called broadcast_change()"
-    Logger.debug "Added new reading to the DB"
+
+    # broadcast_change(:added)
+    # Logger.debug "Added new reading and called broadcast_change()"
+    Logger.debug("Added new reading to the DB")
   end
 
   # This method looks for a single row in the reading_metadata table and
   # updates it with the values past in from the sensor client
   def set_reading_metadata(attrs \\ %{}) do
-    Logger.debug "reading_metadata: #{inspect(attrs)}"
-    id = 1;
+    Logger.debug("reading_metadata: #{inspect(attrs)}")
+    id = 1
+
     result =
       case Repo.get(Ambi.ReadingMetadata, id) do
-        nil  -> %Ambi.ReadingMetadata{id: id} # ReadingMetadata instance not found, we build one
-        reading_metadata -> reading_metadata  # ReadingMetadata instance exists, let's use it
+        # ReadingMetadata instance not found, we build one
+        nil -> %Ambi.ReadingMetadata{id: id}
+        # ReadingMetadata instance exists, let's use it
+        reading_metadata -> reading_metadata
       end
       |> Ambi.ReadingMetadata.changeset(attrs)
-      |> Repo.insert_or_update
-    Logger.debug "result: #{inspect(result)}"
+      |> Repo.insert_or_update()
 
-    #case result do
+    Logger.debug("result: #{inspect(result)}")
+
+    # case result do
     #  {:ok, _struct}       -> Logger.debug "** Set reading metadata successfully"
     #  {:error, _changeset} -> Logger.error "** Failed to update the ReadingMetadata table"
-    #end
+    # end
   end
 
   def get_reading_metadata() do
@@ -57,7 +62,8 @@ defmodule Ambi do
   end
 
   def get_reading() do
-    %{temperature: get_temp(),
+    %{
+      temperature: get_temp(),
       humidity: get_humidity(),
       pressure: get_pressure(),
       dust_concentration: get_dust_concentration(),
@@ -85,6 +91,7 @@ defmodule Ambi do
       from Ambi.Reading,
         order_by: [desc: :humidity],
         limit: 2
+
     Repo.aggregate(query, :avg, :humidity)
     get_last_row().humidity
   end
@@ -108,7 +115,7 @@ defmodule Ambi do
 
   # Gets the average temperature from the DB over the last 24 hour period
   def get_average_temp_24hrs() do
-    one_day_ago = Timex.shift(Timex.now, hours: -24, minutes: 0)
+    one_day_ago = Timex.shift(Timex.now(), hours: -24, minutes: 0)
 
     query =
       from r in Ambi.Reading,
@@ -127,27 +134,28 @@ defmodule Ambi do
   end
 
   def get_temperatures_over_120s() do
-    two_mins_ago = Timex.shift(Timex.now, hours: 0, minutes: -4)
+    two_mins_ago = Timex.shift(Timex.now(), hours: 0, minutes: -4)
 
     query =
       from r in Ambi.Reading,
-      order_by: [desc: :inserted_at],
-      where: r.inserted_at >= ^two_mins_ago,
-      select: {r.temperature},
-      limit: 25 # temporary
+        order_by: [desc: :inserted_at],
+        where: r.inserted_at >= ^two_mins_ago,
+        select: {r.temperature},
+        # temporary
+        limit: 25
 
     Repo.all(query)
   end
 
   def get_avg_temperature_over_1hr(hour) do
-    n_hours_ago = Timex.shift(Timex.now, hours: hour, minutes: 0)
-    nm_hours_ago = Timex.shift(Timex.now, hours: hour+1, minutes: 0)
+    n_hours_ago = Timex.shift(Timex.now(), hours: hour, minutes: 0)
+    nm_hours_ago = Timex.shift(Timex.now(), hours: hour + 1, minutes: 0)
 
     query =
       from r in Ambi.Reading,
-      order_by: [desc: :inserted_at],
-      where: r.inserted_at >= ^n_hours_ago and r.inserted_at < ^nm_hours_ago,
-      select: {r.temperature}
+        order_by: [desc: :inserted_at],
+        where: r.inserted_at >= ^n_hours_ago and r.inserted_at < ^nm_hours_ago,
+        select: {r.temperature}
 
     Repo.aggregate(query, :avg, :temperature)
   end
@@ -164,9 +172,10 @@ defmodule Ambi do
     Repo.aggregate(Ambi.Reading, :avg, :humidity)
   end
 
- # Gets the average humidity from the DB over the last 24 hour period
+  # Gets the average humidity from the DB over the last 24 hour period
   def get_average_humidity_24hrs() do
-    one_day_ago = Timex.shift(Timex.now, hours: -24, minutes: 0)
+    one_day_ago = Timex.shift(Timex.now(), hours: -24, minutes: 0)
+
     query =
       from r in Ambi.Reading,
         order_by: [desc: :inserted_at],
@@ -184,26 +193,26 @@ defmodule Ambi do
   end
 
   def get_humidities_over_24hrs() do
-    twenty_four_hours_ago = Timex.shift(Timex.now, hours: -24, minutes: 0)
+    twenty_four_hours_ago = Timex.shift(Timex.now(), hours: -24, minutes: 0)
 
     query =
       from r in Ambi.Reading,
-      order_by: [desc: :inserted_at],
-      where: r.inserted_at >= ^twenty_four_hours_ago,
-      select: {r.humidity}
+        order_by: [desc: :inserted_at],
+        where: r.inserted_at >= ^twenty_four_hours_ago,
+        select: {r.humidity}
 
     Repo.all(query)
   end
 
   def get_avg_humidity_over_1hr(hour) do
-    n_hours_ago = Timex.shift(Timex.now, hours: hour, minutes: 0)
-    nm_hours_ago = Timex.shift(Timex.now, hours: hour+1, minutes: 0)
+    n_hours_ago = Timex.shift(Timex.now(), hours: hour, minutes: 0)
+    nm_hours_ago = Timex.shift(Timex.now(), hours: hour + 1, minutes: 0)
 
     query =
       from r in Ambi.Reading,
-      order_by: [desc: :inserted_at],
-      where: r.inserted_at >= ^n_hours_ago and r.inserted_at < ^nm_hours_ago,
-      select: {r.humidity}
+        order_by: [desc: :inserted_at],
+        where: r.inserted_at >= ^n_hours_ago and r.inserted_at < ^nm_hours_ago,
+        select: {r.humidity}
 
     Repo.aggregate(query, :avg, :humidity)
   end
@@ -239,20 +248,23 @@ defmodule Ambi do
   @topic inspect(__MODULE__)
   def subscribe() do
     PubSub.subscribe(Ambi.PubSub, @topic)
-    Logger.debug """
+
+    Logger.debug("""
     Subscribe details:
     topic: #{inspect(@topic)}
-    """
+    """)
   end
 
   def broadcast_change(event) do
     PubSub.broadcast(Ambi.PubSub, @topic, event)
-    Logger.debug """
+
+    Logger.debug("""
     Broadcast details:
     topic: #{inspect(@topic)}
     module: #{inspect(__MODULE__)}
     event: #{inspect(event)}
-    """
+    """)
+
     :ok
   end
 end

--- a/lib/ambi/timer.ex
+++ b/lib/ambi/timer.ex
@@ -5,12 +5,14 @@ defmodule Ambi.Timer do
   def start_link(state) do
     GenServer.start_link(__MODULE__, state, name: __MODULE__)
   end
+
   ## SERVER ##
 
   def init(_state) do
-    Logger.warn "Ambi timer server started"
+    Logger.warn("Ambi timer server started")
     broadcast()
-    schedule_timer(10_000) # 1 sec timer
+    # 1 sec timer
+    schedule_timer(10_000)
     {:ok, 0}
   end
 

--- a/lib/ambi_web/controllers/api_controller.ex
+++ b/lib/ambi_web/controllers/api_controller.ex
@@ -17,6 +17,7 @@ defmodule AmbiWeb.ApiController do
 
   def reset(conn, _params) do
     Ambi.reset_readings()
+
     html(conn, """
       <html>
         <head>

--- a/lib/ambi_web/endpoint.ex
+++ b/lib/ambi_web/endpoint.ex
@@ -55,11 +55,11 @@ defmodule AmbiWeb.Endpoint do
   plug AmbiWeb.Router
 
   def introspect(conn, _opts) do
-    IO.puts """
+    IO.puts("""
     Verb: #{inspect(conn.method)}
     Host: #{inspect(conn.host)}
     Headers: #{inspect(conn.req_headers)}
-    """
+    """)
 
     conn
   end

--- a/lib/ambi_web/live/reading_live.ex
+++ b/lib/ambi_web/live/reading_live.ex
@@ -4,7 +4,7 @@ defmodule AmbiWeb.ReadingLive do
   require Logger
 
   def mount(_params, _session, socket) do
-    Logger.debug "ReadingLive.mount() called, subscribing PubSub topic"
+    Logger.debug("ReadingLive.mount() called, subscribing PubSub topic")
     Ambi.subscribe()
 
     socket = assign(socket, %{reading: Ambi.get_reading()})
@@ -12,16 +12,17 @@ defmodule AmbiWeb.ReadingLive do
   end
 
   def handle_info(:added, socket) do
-    Logger.debug "Received :added event message"
+    Logger.debug("Received :added event message")
     {:noreply, assign(socket, %{reading: Ambi.get_reading()})}
   end
 
   def handle_info(:reading_refresh, socket) do
-    Logger.debug "Received :refresh_reading event message"
-    {:noreply, assign(socket, %{reading: Ambi.get_reading()})
+    Logger.debug("Received :refresh_reading event message")
+
+    {:noreply,
+     assign(socket, %{reading: Ambi.get_reading()})
      |> push_event("humidity_points", %{humidity_points: get_humidities()})
-     |> push_event("temperature_points", %{temperature_points: get_temperatures()})
-    }
+     |> push_event("temperature_points", %{temperature_points: get_temperatures()})}
   end
 
   defp get_temperatures do
@@ -29,9 +30,9 @@ defmodule AmbiWeb.ReadingLive do
   end
 
   defp get_humidities do
-    #timestamp_resolution_seconds = Ambi.get_timestamp_resolution_seconds()
-    #Logger.debug "****** #{inspect(timestamp_resolution_seconds)}"
-    #label_every_nth_point = div(86000, timestamp_resolution_seconds)
+    # timestamp_resolution_seconds = Ambi.get_timestamp_resolution_seconds()
+    # Logger.debug "****** #{inspect(timestamp_resolution_seconds)}"
+    # label_every_nth_point = div(86000, timestamp_resolution_seconds)
 
     Ambi.get_avg_humidities_over_24hrs()
   end

--- a/priv/repo/migrations/20210207211037_create_readings.exs
+++ b/priv/repo/migrations/20210207211037_create_readings.exs
@@ -11,6 +11,5 @@ defmodule Ambi.Repo.Migrations.CreateReadings do
 
       timestamps()
     end
-
   end
 end

--- a/scripts/create-git-hooks
+++ b/scripts/create-git-hooks
@@ -1,0 +1,24 @@
+# This script was taken from a StackOverflow answer that can be found at
+# https://stackoverflow.com/a/3464399
+#
+# This is used under the CC BY-SA 4.0 license:
+# https://creativecommons.org/licenses/by-sa/4.0/
+#
+# This file has been modified from its original form to include a BASE_DIR variable
+
+
+#!/bin/bash
+HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch pre-commit prepare-commit-msg commit-msg post-commit pre-rebase post-checkout post-merge pre-receive update post-receive post-update pre-auto-gc"
+BASE_DIR=$(git rev-parse --show-toplevel)
+HOOK_DIR=$BASE_DIR/.git/hooks
+
+for hook in $HOOK_NAMES; do
+    # If the hook already exists, is executable, and is not a symlink
+    if [ ! -h $HOOK_DIR/$hook -a -x $HOOK_DIR/$hook ]; then
+        mv $HOOK_DIR/$hook $HOOK_DIR/$hook.local
+    fi
+    # create the symlink, overwriting the file if it exists
+    # probably the only way this would happen is if you're using an old version of git
+    # -- back when the sample hooks were not executable, instead of being named ____.sample
+    ln -s -f $BASE_DIR/scripts/hooks-wrapper $HOOK_DIR/$hook
+done

--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eo pipefail
+
+mix format
+
+# Stage changes to files that were already staged
+git update-index --again

--- a/scripts/hooks-wrapper
+++ b/scripts/hooks-wrapper
@@ -1,0 +1,12 @@
+# This script was taken from a StackOverflow answer that can be found at
+# https://stackoverflow.com/a/3464399
+# This is used under the CC BY-SA 4.0 license:
+# https://creativecommons.org/licenses/by-sa/4.0/
+
+#!/bin/bash
+if [ -x $0.local ]; then
+    $0.local "$@" || exit $?
+fi
+if [ -x scripts/git/$(basename $0) ]; then
+    scripts/git/$(basename $0) "$@" || exit $?
+fi


### PR DESCRIPTION
This change adds a new pre-commit hook that will run `mix format` and add the changed files to the commit. This ensures that all of the code in the repository meets our code quality standards, and removes the responsibility of running the `format` command from the author so that they are not forced to remember and reviewers do not need to ask for formatting updates. This also conveniently adds the updates to the commit containing the changed files so that the author does not need to do any squashing or fixing up later.

To install the new commit hook in your local workspace, you can run `./scripts/create-git-hooks`, which will set up a symlink to a hooks-wrapper script that can run any commit hook that we currently have or add in the future.

As part of this change, I also ran `mix format` ahead of time and added them as a separate commit so that the files wouldn't get added in the commit to add the hook.

Relates to #14 