### PR TITLE
Update create-git-hooks to create Git hooks dir if missing

### DIFF
--- a/scripts/create-git-hooks
+++ b/scripts/create-git-hooks
@@ -5,12 +5,17 @@
 # https://creativecommons.org/licenses/by-sa/4.0/
 #
 # This file has been modified from its original form to include a BASE_DIR variable
+# and to include creation of the Git hooks directory if it does not already exist
 
 
 #!/bin/bash
 HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch pre-commit prepare-commit-msg commit-msg post-commit pre-rebase post-checkout post-merge pre-receive update post-receive post-update pre-auto-gc"
 BASE_DIR=$(git rev-parse --show-toplevel)
 HOOK_DIR=$BASE_DIR/.git/hooks
+
+if [ ! -d $HOOK_DIR ]; then
+  mkdir $HOOK_DIR
+fi
 
 for hook in $HOOK_NAMES; do
     # If the hook already exists, is executable, and is not a symlink


### PR DESCRIPTION
I spotted an issue when setting up other applications with the Git hooks where it was possible for the `.git/hooks` directory to not exist. The change in this PR enhances the `create-git-hooks` script to create the hooks directory if it does not already exist